### PR TITLE
Feature webxml cookiename

### DIFF
--- a/manifests/cookie_name.pp
+++ b/manifests/cookie_name.pp
@@ -6,7 +6,7 @@ class io_weblogic::cookie_name (
   $pia_domain_list.each |$domain_name, $pia_domain_info| {
     $ps_cfg_home_dir = $pia_domain_info['ps_cfg_home_dir']
 
-    if (!${pia_cookie_name}) {
+    if (!$pia_cookie_name) {
       $pia_cookie_name = "${pia_domain_name}-PSJSESSIONID"
     }
 

--- a/manifests/cookie_name.pp
+++ b/manifests/cookie_name.pp
@@ -1,0 +1,20 @@
+class io_weblogic::cookie_name (
+  $pia_domain_list = $io_weblogic::params::pia_domain_list,
+  $pia_cookie_name = $io_weblogic::params::pia_cookie_name,
+) inherits io_weblogic::params {
+
+  $pia_domain_list.each |$domain_name, $pia_domain_info| {
+    $ps_cfg_home_dir = $pia_domain_info['ps_cfg_home_dir']
+
+    if (!${pia_domain_name}) {
+      $pia_cookie_name = "${pia_domain_name}-PSJSESSIONID"
+    }
+
+    augeas { "${pia_domain_name} weblogic.xml cookie-name" :
+      lens    => 'Xml.lns',
+      incl    => "${ps_config_home}/webserv/${pia_domain_name}/applications/peoplesoft/PORTAL.war/WEB-INF/weblogic.xml",
+      context => "/files/${ps_config_home}/webserv/${pia_domain_name}/applications/peoplesoft/PORTAL.war/WEB-INF/weblogic.xml/weblogic-web-app/session-descriptor/cookie-name",
+      changes => "set #text ${pia_cookie_name}",
+    }
+  }
+}

--- a/manifests/cookie_name.pp
+++ b/manifests/cookie_name.pp
@@ -4,16 +4,19 @@ class io_weblogic::cookie_name (
 ) inherits io_weblogic::params {
 
   $pia_domain_list.each |$domain_name, $pia_domain_info| {
+
     $ps_cfg_home_dir = $pia_domain_info['ps_cfg_home_dir']
 
     if (!$pia_cookie_name) {
-      $pia_cookie_name = "${pia_domain_name}-PSJSESSIONID"
+      $pia_cookie_name = "${domain_name}-PSJSESSIONID"
     }
 
-    augeas { "${pia_domain_name} weblogic.xml cookie-name" :
+    notify { "domain: ${domain_name}" :}
+
+    augeas { "${domain_name} weblogic.xml cookie-name" :
       lens    => 'Xml.lns',
-      incl    => "${ps_config_home}/webserv/${pia_domain_name}/applications/peoplesoft/PORTAL.war/WEB-INF/weblogic.xml",
-      context => "/files/${ps_config_home}/webserv/${pia_domain_name}/applications/peoplesoft/PORTAL.war/WEB-INF/weblogic.xml/weblogic-web-app/session-descriptor/cookie-name",
+      incl    => "${ps_cfg_home_dir}/webserv/${domain_name}/applications/peoplesoft/PORTAL.war/WEB-INF/weblogic.xml",
+      context => "/files/${ps_cfg_home_dir}/webserv/${domain_name}/applications/peoplesoft/PORTAL.war/WEB-INF/weblogic.xml/weblogic-web-app/session-descriptor/cookie-name",
       changes => "set #text ${pia_cookie_name}",
     }
   }

--- a/manifests/cookie_name.pp
+++ b/manifests/cookie_name.pp
@@ -6,7 +6,7 @@ class io_weblogic::cookie_name (
   $pia_domain_list.each |$domain_name, $pia_domain_info| {
     $ps_cfg_home_dir = $pia_domain_info['ps_cfg_home_dir']
 
-    if (!${pia_domain_name}) {
+    if (!${pia_cookie_name}) {
       $pia_cookie_name = "${pia_domain_name}-PSJSESSIONID"
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@ class io_weblogic (
     include ::io_weblogic::cacert
   }
 
-  if ($io_weblogic::params::rename_webxml_cookie) {
-    include ::io_weblogic::cacert
+  if ($io_weblogic::params::rename_pia_cookie) {
+    include ::io_weblogic::cookie_name
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,4 +12,8 @@ class io_weblogic (
   if ($io_weblogic::params::standard_java_trust) or ($io_weblogic::params::cacert_passwd != 'password'){
     include ::io_weblogic::cacert
   }
+
+  if ($io_weblogic::params::rename_webxml_cookie) {
+    include ::io_weblogic::cacert
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,7 +6,7 @@ class io_weblogic::params (
   $cacert_passwd        = 'changeit',
   $trustcacerts         = true,
   $standard_java_trust  = true,
-  $rename_webxml_cookie = false,
+  $rename_pia_cookie    = false,
   $java_options         = undef,
   $certificates         = undef,
   $pia_cookie_name      = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,13 +1,15 @@
 class io_weblogic::params (
-  $ensure              = hiera('ensure', 'present'),
-  $java_home           = hiera('jdk_location'),
-  $pia_domain_list     = hiera_hash('pia_domain_list'),
-  $pskey_passwd        = 'password',
-  $cacert_passwd       = 'changeit',
-  $trustcacerts        = true,
-  $standard_java_trust = true,
-  $java_options        = undef,
-  $certificates        = undef,
+  $ensure               = hiera('ensure', 'present'),
+  $java_home            = hiera('jdk_location'),
+  $pia_domain_list      = hiera_hash('pia_domain_list'),
+  $pskey_passwd         = 'password',
+  $cacert_passwd        = 'changeit',
+  $trustcacerts         = true,
+  $standard_java_trust  = true,
+  $rename_webxml_cookie = false,
+  $java_options         = undef,
+  $certificates         = undef,
+  $pia_cookie_name      = undef,
 ){
 
   case $::facts['os']['name'] {

--- a/tests/cacert.pp
+++ b/tests/cacert.pp
@@ -1,0 +1,12 @@
+# The baseline for module testing used by Puppet Labs is that each manifest
+# should have a corresponding test manifest that declares that class or defined
+# type.
+#
+# Tests are then run by using puppet apply --noop (to check for compilation
+# errors and view a log of events) or by fully applying the test in a virtual
+# environment (to compare the resulting system state to the desired state).
+#
+# Learn more about module testing here:
+# http://docs.puppetlabs.com/guides/tests_smoke.html
+#
+include io_weblogic::cacert

--- a/tests/cookie_name.pp
+++ b/tests/cookie_name.pp
@@ -1,0 +1,12 @@
+# The baseline for module testing used by Puppet Labs is that each manifest
+# should have a corresponding test manifest that declares that class or defined
+# type.
+#
+# Tests are then run by using puppet apply --noop (to check for compilation
+# errors and view a log of events) or by fully applying the test in a virtual
+# environment (to compare the resulting system state to the desired state).
+#
+# Learn more about module testing here:
+# http://docs.puppetlabs.com/guides/tests_smoke.html
+#
+include io_weblogic::cookie_name


### PR DESCRIPTION
Class, params and init call added for WebLogic web.xml cookie rename

This feature is meant to let those PS customers who desire to, to
rename the PSJSESSIONID cookie to their standard