### PR TITLE
Add ::osfamily windows code for  JAVA_OPTS_WIN

### DIFF
--- a/manifests/cacert.pp
+++ b/manifests/cacert.pp
@@ -8,11 +8,20 @@ class io_weblogic::cacert (
 
   $cacert_location    = "${java_home}/jre/lib/security/cacerts"
 
-  exec { "Set the cacert password for ${cacert_location}":
-    command => "keytool -keystore ${cacert_location} -storepass changeit -storepasswd -new ${password}",
-    onlyif  => "keytool -list -keystore ${cacert_location} -storepass ${password} |/bin/grep \"password was incorrect\"",
-    path    => "${java_home}/jre/bin/",
-    #require => Pt_webserver_domain[$pia_domain_name],
+  if $::osfamily == 'windows' {
+    exec { "Set the cacert password for ${cacert_location}":
+      command => "keytool -keystore ${cacert_location} -storepass changeit -storepasswd -new ${password}",
+      onlyif  => "keytool -list -keystore ${cacert_location} -storepass ${password}",
+      path    => "${java_home}/jre/bin/",
+      #require => Pt_webserver_domain[$pia_domain_name],
+    }
+  } else {
+    exec { "Set the cacert password for ${cacert_location}":
+      command => "keytool -keystore ${cacert_location} -storepass changeit -storepasswd -new ${password}",
+      onlyif  => "keytool -list -keystore ${cacert_location} -storepass ${password} |/bin/grep \"password was incorrect\"",
+      path    => "${java_home}/jre/bin/",
+      #require => Pt_webserver_domain[$pia_domain_name],
+    }
   }
 
   $pia_domain_list.each |$domain_name, $pia_domain_info| {
@@ -20,12 +29,21 @@ class io_weblogic::cacert (
     $ps_cfg_home_dir = $pia_domain_info['ps_cfg_home_dir']
 
     if $standard_java_trust {
-      file_line { 'Set javax.net.ssl.trustStore from delivered to cacerts':
-        ensure => present,
-        path   => "${ps_cfg_home_dir}/webserv/${domain_name}/bin/${setenv}",
-        line   => "SSL_KEY_STORE_PATH=${cacert_location}",
-        match  => '^SSL_KEY_STORE_PATH=.*'
-      }
-    }
+      if $::osfamily == 'windows' {
+        file_line { 'Set javax.net.ssl.trustStore from delivered to cacerts':
+          ensure => present,
+          path   => "${ps_cfg_home_dir}/webserv/${domain_name}/bin/${setenv}",
+          line   => "SET SSL_KEY_STORE_PATH=${cacert_location}",
+          match  => '^SET SSL_KEY_STORE_PATH=.*'
+        }
+      } else {
+        file_line { 'Set javax.net.ssl.trustStore from delivered to cacerts':
+          ensure => present,
+          path   => "${ps_cfg_home_dir}/webserv/${domain_name}/bin/${setenv}",
+          line   => "SSL_KEY_STORE_PATH=${cacert_location}",
+          match  => '^SSL_KEY_STORE_PATH=.*'
+        }
+      } # end osfamily check
+    } 
   }
 }

--- a/manifests/java_options.pp
+++ b/manifests/java_options.pp
@@ -10,19 +10,37 @@ class io_weblogic::java_options (
 
     $ps_cfg_home_dir = $pia_domain_info['ps_cfg_home_dir']
 
-    Ini_Subsetting {
-      ensure               => $ensure,
-      path                 => "${ps_cfg_home_dir}/webserv/${domain_name}/bin/${setenv}",
-      setting              => "JAVA_OPTIONS_${platform}",
-      subsetting_separator => ' -',
-      section              => '',
-    }
+    if $::osfamily == 'windows' {
+      Ini_Subsetting {
+        ensure               => $ensure,
+        path                 => "${ps_cfg_home_dir}/webserv/${domain_name}/bin/${setenv}",
+        setting              => "SET JAVA_OPTIONS_${platform}",
+        subsetting_separator => ' -',
+        section              => '',
+      }
 
-    $settings["${domain_name}"].each | $subset, $val | {
-      ini_subsetting { "${domain_name} WLS JAVA_OPTIONS_${platform}, ${subset}, ${val}" :
-        subsetting => $subset,
-        value      => $val,
+      $settings["${domain_name}"].each | $subset, $val | {
+        ini_subsetting { "${domain_name} WLS JAVA_OPTIONS_${platform}, ${subset}, ${val}" :
+          subsetting => $subset,
+          value      => $val,
+        }
+      }
+    } else {
+     Ini_Subsetting {
+        ensure               => $ensure,
+        path                 => "${ps_cfg_home_dir}/webserv/${domain_name}/bin/${setenv}",
+        setting              => "JAVA_OPTIONS_${platform}",
+        subsetting_separator => ' -',
+        section              => '',
+      }
+
+      $settings["${domain_name}"].each | $subset, $val | {
+        ini_subsetting { "${domain_name} WLS JAVA_OPTIONS_${platform}, ${subset}, ${val}" :
+          subsetting => $subset,
+          value      => $val,
+        }
       }
     }
+    
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -66,7 +66,7 @@ class io_weblogic::params (
     }
   }
 
-  validate_hash($java_options)
-  validate_hash($certificates)
+  if $java_options { validate_hash($java_options) }
+  if $certificates { validate_hash($certificates) }
   validate_hash($pia_domain_list)
 }


### PR DESCRIPTION
Added ::osfamily == 'windows' code for 

* `JAVA_OPTIONS_WIN`
* `SSL_KEY_STORE_PATH`

Added (but not tested) windows code for `keytool`. Most windows machines won't have `grep` so I removed that check for now.

Added conditional statements before two `validate_hash` function calls. If a hash is not defined the `validate_hash` call will fail. 