### PR TITLE
Remove class default subsetting_separator to address #10

### DIFF
--- a/manifests/java_options.pp
+++ b/manifests/java_options.pp
@@ -14,7 +14,6 @@ class io_weblogic::java_options (
       ensure               => $ensure,
       path                 => "${ps_cfg_home_dir}/webserv/${domain_name}/bin/${setenv}",
       setting              => "${javaopt_set}${platform}",
-      subsetting_separator => ' -',
       section              => '',
     }
 


### PR DESCRIPTION
This change will require updates to Hiera data. The hash key name requires a `-` at the beginning. E.g, 

```
io_weblogic::java_options:
  "%{hiera('db_name')}":
    -Xms:                              '256m'
    -Xmx:                              '256m'
    -Dweblogic.threadpool.MinPoolSize: '=50'
    -Dhttps.protocols:                 '=TLSv1.2'
```

This is to address #10 where it was breaking the Windows `setEnv.cmd` file.