### PR TITLE
Refactor params

### DIFF
--- a/manifests/cacert.pp
+++ b/manifests/cacert.pp
@@ -5,7 +5,7 @@ class io_weblogic::cacert (
   $standard_java_trust = $io_weblogic::standard_java_trust,
   $setenv              = $io_weblogic::setenv,
   $keystr_set          = $io_weblogic::keystr_set,
-) inherits io_weblogic {
+) {
 
   $cacert_location    = "${java_home}/jre/lib/security/cacerts"
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,93 +1,34 @@
 class io_weblogic (
-  $ensure                    = hiera('ensure', 'present'),
-  $java_home                 = hiera('jdk_location'),
-  $tools_version             = hiera('tools_version'),
-  $psft_install_user_name    = hiera('psft_install_user_name', undef),
-  $oracle_install_group_name = hiera('oracle_install_group_name', undef),
-  $domain_user               = hiera('domain_user', undef),
-  $pia_domain_list           = hiera_hash('pia_domain_list'),
-  $install_jce               = false,
-  $trustcacerts              = false,
-  $standard_java_trust       = false,
-  $pskey_passwd              = 'password',
-  $cacert_passwd             = 'changeit',
-  $java_options              = undef,
-  $certificates              = undef,
-  $jce_path                  = undef,
-) {
-
-  if $java_options    { validate_hash($java_options)    }
-  if $certificates    { validate_hash($certificates)    }
-  if $pia_domain_list { validate_hash($pia_domain_list) }
-
-  if (!$jce_path) {
-    case $tools_version {
-      /8\.54\.*/: {
-        $jce_archive_path = 'http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip'
-      }
-      /8\.55\.*/: {
-        $jce_archive_path = 'http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip'
-      }
-      /8\.56\.*/: {
-        $jce_archive_path = 'http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip'
-      }
-      default: {
-        fail("Module ${module_name} requires that you have tools_version defined in your hiera to download JCE from Oracle")
-      }
-    }
-  }
-  else {
-    $jce_archive_path = $jce_path
-  }
-
-  case $::osfamily {
-    'windows': {
-      $platform        = 'WIN'
-      $setenv          = 'setEnv.cmd'
-      $extract_command = '7z e -y -o'
-      $fileowner       = $domain_user
-      $keystr_set      = 'SET SSL_KEY_STORE_PATH'
-      $javaopt_set     = 'SET JAVA_OPTIONS_'
-    }
-    'AIX': {
-      $platform = 'AIX'
-      $setenv          = 'setEnv.sh'
-      $extract_command = 'unzip -o -j %s -d '
-      $fileowner       = $psft_install_user_name
-      $keystr_set      = 'SSL_KEY_STORE_PATH'
-      $javaopt_set     = 'JAVA_OPTIONS_'
-    }
-    'Solaris': {
-      $platform = 'SOLARIS'
-      $setenv          = 'setEnv.sh'
-      $extract_command = 'unzip -o -j %s -d '
-      $fileowner       = $psft_install_user_name
-      $keystr_set      = 'SSL_KEY_STORE_PATH'
-      $javaopt_set     = 'JAVA_OPTIONS_'
-    }
-    default: {
-      $platform = 'LINUX'
-      $setenv          = 'setEnv.sh'
-      $extract_command = 'unzip -o -j %s -d '
-      $fileowner       = $psft_install_user_name
-      $keystr_set      = 'SSL_KEY_STORE_PATH'
-      $javaopt_set     = 'JAVA_OPTIONS_'
-    }
-  }
+  $ensure                    = $::io_weblogic::params::ensure
+  $java_home                 = $::io_weblogic::params::java_home,
+  $tools_version             = $::io_weblogic::params::tools_version,
+  $psft_install_user_name    = $::io_weblogic::params::psft_install_user_name,
+  $oracle_install_group_name = $::io_weblogic::params::oracle_install_group_name,
+  $domain_user               = $::io_weblogic::params::domain_user,
+  $pia_domain_list           = $::io_weblogic::params::pia_domain_list,
+  $install_jce               = $::io_weblogic::params::install_jce,
+  $trustcacerts              = $::io_weblogic::params::trustcacerts,
+  $standard_java_trust       = $::io_weblogic::params::standard_java_trust,
+  $pskey_passwd              = $::io_weblogic::params::pskey_passwd,
+  $cacert_passwd             = $::io_weblogic::params::cacert_passwd,
+  $java_options              = $::io_weblogic::params::java_options,
+  $certificates              = $::io_weblogic::params::certificates,
+  $jce_path                  = $::io_weblogic::params::jce_path,
+) inherits ::io_weblogic::params {
 
   if ($java_options != undef) {
-    contain ::io_weblogic::java_options
+    include ::io_weblogic::java_options
   }
 
   if ($certificates != undef) or ($pskey_passwd != 'password'){
-    contain ::io_weblogic::pskey
+    include ::io_weblogic::pskey
   }
 
   if ($standard_java_trust) or ($cacert_passwd != 'changeit'){
-    contain ::io_weblogic::cacert
+    include ::io_weblogic::cacert
   }
 
   if ($install_jce){
-    contain ::io_weblogic::jce
+    include ::io_weblogic::jce
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,18 +17,18 @@ class io_weblogic (
 ) inherits ::io_weblogic::params {
 
   if ($java_options != undef) {
-    include ::io_weblogic::java_options
+    contain ::io_weblogic::java_options
   }
 
   if ($certificates != undef) or ($pskey_passwd != 'password'){
-    include ::io_weblogic::pskey
+    contain ::io_weblogic::pskey
   }
 
   if ($standard_java_trust) or ($cacert_passwd != 'changeit'){
-    include ::io_weblogic::cacert
+    contain ::io_weblogic::cacert
   }
 
   if ($install_jce){
-    include ::io_weblogic::jce
+    contain ::io_weblogic::jce
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,5 @@
 class io_weblogic (
-  $ensure                    = $::io_weblogic::params::ensure
+  $ensure                    = $::io_weblogic::params::ensure,
   $java_home                 = $::io_weblogic::params::java_home,
   $tools_version             = $::io_weblogic::params::tools_version,
   $psft_install_user_name    = $::io_weblogic::params::psft_install_user_name,

--- a/manifests/java_options.pp
+++ b/manifests/java_options.pp
@@ -5,7 +5,7 @@ class io_weblogic::java_options (
   $platform        = $io_weblogic::platform,
   $setenv          = $io_weblogic::setenv,
   $javaopt_set     = $io_weblogic::javaopt_set,
-) inherits io_weblogic {
+) {
 
   $pia_domain_list.each |$domain_name, $pia_domain_info| {
 

--- a/manifests/jce.pp
+++ b/manifests/jce.pp
@@ -5,7 +5,7 @@ class io_weblogic::jce (
   $extract_command          = $io_weblogic::extract_command,
   $fileowner                = $io_weblogic::fileowner,
   $oracle_install_user_name = $io_weblogic::oracle_install_user_name,
-) inherits io_weblogic{
+) {
 
   $security_dir = "${java_home}/jre/lib/security"
 

--- a/manifests/jce.pp
+++ b/manifests/jce.pp
@@ -1,11 +1,32 @@
 class io_weblogic::jce (
   $ensure                   = $io_weblogic::ensure,
-  $jce_archive_path         = $io_weblogic::jce_archive_path,
+  $jce_path                 = $io_weblogic::jce_path,
   $java_home                = $io_weblogic::java_home,
   $extract_command          = $io_weblogic::extract_command,
   $fileowner                = $io_weblogic::fileowner,
   $oracle_install_user_name = $io_weblogic::oracle_install_user_name,
+  $tools_version            = $io_weblogic::tools_version,
 ) {
+
+  if (!$jce_path) {
+    case $tools_version {
+      /8\.54\.*/: {
+        $jce_archive_path = 'http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip'
+      }   
+      /8\.55\.*/: {
+        $jce_archive_path = 'http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip'
+      }   
+      /8\.56\.*/: {
+        $jce_archive_path = 'http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip'
+      }   
+      default: {
+        fail("Module ${module_name} requires that you have tools_version defined in your hiera to download JCE from Oracle")
+      }   
+    }   
+  }
+  else {
+    $jce_archive_path = $jce_path
+  }
 
   $security_dir = "${java_home}/jre/lib/security"
 

--- a/manifests/jce.pp
+++ b/manifests/jce.pp
@@ -12,17 +12,17 @@ class io_weblogic::jce (
     case $tools_version {
       /8\.54\.*/: {
         $jce_archive_path = 'http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip'
-      }   
+      }
       /8\.55\.*/: {
         $jce_archive_path = 'http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip'
-      }   
+      }
       /8\.56\.*/: {
         $jce_archive_path = 'http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip'
-      }   
+      }
       default: {
         fail("Module ${module_name} requires that you have tools_version defined in your hiera to download JCE from Oracle")
-      }   
-    }   
+      }
+    }
   }
   else {
     $jce_archive_path = $jce_path

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,26 +19,6 @@ class io_weblogic::params {
   if $certificates    { validate_hash($certificates)    }
   if $pia_domain_list { validate_hash($pia_domain_list) }
 
-  if (!$jce_path) {
-    case $tools_version {
-      /8\.54\.*/: {
-        $jce_archive_path = 'http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip'
-      }
-      /8\.55\.*/: {
-        $jce_archive_path = 'http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip'
-      }
-      /8\.56\.*/: {
-        $jce_archive_path = 'http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip'
-      }
-      default: {
-        fail("Module ${module_name} requires that you have tools_version defined in your hiera to download JCE from Oracle")
-      }
-    }
-  }
-  else {
-    $jce_archive_path = $jce_path
-  }
-
   case $::osfamily {
     'windows': {
       $platform        = 'WIN'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,76 @@
+class io_weblogic::params {
+  $ensure                    = hiera('ensure', 'present')
+  $java_home                 = hiera('jdk_location')
+  $tools_version             = hiera('tools_version')
+  $psft_install_user_name    = hiera('psft_install_user_name', undef)
+  $oracle_install_group_name = hiera('oracle_install_group_name', undef)
+  $domain_user               = hiera('domain_user', undef)
+  $pia_domain_list           = hiera_hash('pia_domain_list')
+  $install_jce               = false
+  $trustcacerts              = false
+  $standard_java_trust       = false
+  $pskey_passwd              = 'password'
+  $cacert_passwd             = 'changeit'
+  $java_options              = undef
+  $certificates              = undef
+  $jce_path                  = undef
+
+  if $java_options    { validate_hash($java_options)    }
+  if $certificates    { validate_hash($certificates)    }
+  if $pia_domain_list { validate_hash($pia_domain_list) }
+
+  if (!$jce_path) {
+    case $tools_version {
+      /8\.54\.*/: {
+        $jce_archive_path = 'http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip'
+      }
+      /8\.55\.*/: {
+        $jce_archive_path = 'http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip'
+      }
+      /8\.56\.*/: {
+        $jce_archive_path = 'http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip'
+      }
+      default: {
+        fail("Module ${module_name} requires that you have tools_version defined in your hiera to download JCE from Oracle")
+      }
+    }
+  }
+  else {
+    $jce_archive_path = $jce_path
+  }
+
+  case $::osfamily {
+    'windows': {
+      $platform        = 'WIN'
+      $setenv          = 'setEnv.cmd'
+      $extract_command = '7z e -y -o'
+      $fileowner       = $domain_user
+      $keystr_set      = 'SET SSL_KEY_STORE_PATH'
+      $javaopt_set     = 'SET JAVA_OPTIONS_'
+    }
+    'AIX': {
+      $platform = 'AIX'
+      $setenv          = 'setEnv.sh'
+      $extract_command = 'unzip -o -j %s -d '
+      $fileowner       = $psft_install_user_name
+      $keystr_set      = 'SSL_KEY_STORE_PATH'
+      $javaopt_set     = 'JAVA_OPTIONS_'
+    }
+    'Solaris': {
+      $platform = 'SOLARIS'
+      $setenv          = 'setEnv.sh'
+      $extract_command = 'unzip -o -j %s -d '
+      $fileowner       = $psft_install_user_name
+      $keystr_set      = 'SSL_KEY_STORE_PATH'
+      $javaopt_set     = 'JAVA_OPTIONS_'
+    }
+    default: {
+      $platform = 'LINUX'
+      $setenv          = 'setEnv.sh'
+      $extract_command = 'unzip -o -j %s -d '
+      $fileowner       = $psft_install_user_name
+      $keystr_set      = 'SSL_KEY_STORE_PATH'
+      $javaopt_set     = 'JAVA_OPTIONS_'
+    }
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,12 +1,12 @@
 class io_weblogic::params {
   $ensure                    = 'present'
-  $java_home                 = hiera('jdk_location')
-  $tools_version             = hiera('tools_version')
   $psft_install_user_name    = 'psadm1'
   $oracle_install_group_name = 'oinstall'
   $domain_user               = 'psadm2'
   $pskey_passwd              = 'password'
   $cacert_passwd             = 'changeit'
+  $java_home                 = undef
+  $tools_version             = undef
   $pia_domain_list           = undef
   $install_jce               = false
   $trustcacerts              = false

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,5 @@
 class io_weblogic::params {
-  $ensure                    = present,
+  $ensure                    = 'present'
   $java_home                 = hiera('jdk_location')
   $tools_version             = hiera('tools_version')
   $psft_install_user_name    = 'psadm1'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,9 +2,9 @@ class io_weblogic::params {
   $ensure                    = present,
   $java_home                 = hiera('jdk_location')
   $tools_version             = hiera('tools_version')
-  $psft_install_user_name    = 'psadm1',
-  $oracle_install_group_name = 'oinstall',
-  $domain_user               = 'psadm2',
+  $psft_install_user_name    = 'psadm1'
+  $oracle_install_group_name = 'oinstall'
+  $domain_user               = 'psadm2'
   $pskey_passwd              = 'password'
   $cacert_passwd             = 'changeit'
   $pia_domain_list           = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,16 +1,16 @@
 class io_weblogic::params {
-  $ensure                    = hiera('ensure', 'present')
+  $ensure                    = present,
   $java_home                 = hiera('jdk_location')
   $tools_version             = hiera('tools_version')
-  $psft_install_user_name    = hiera('psft_install_user_name', undef)
-  $oracle_install_group_name = hiera('oracle_install_group_name', undef)
-  $domain_user               = hiera('domain_user', undef)
-  $pia_domain_list           = hiera_hash('pia_domain_list')
+  $psft_install_user_name    = 'psadm1',
+  $oracle_install_group_name = 'oinstall',
+  $domain_user               = 'psadm2',
+  $pskey_passwd              = 'password'
+  $cacert_passwd             = 'changeit'
+  $pia_domain_list           = undef
   $install_jce               = false
   $trustcacerts              = false
   $standard_java_trust       = false
-  $pskey_passwd              = 'password'
-  $cacert_passwd             = 'changeit'
   $java_options              = undef
   $certificates              = undef
   $jce_path                  = undef

--- a/manifests/pskey.pp
+++ b/manifests/pskey.pp
@@ -4,7 +4,7 @@ class io_weblogic::pskey (
   $password        = $io_weblogic::pskey_passwd,
   $certificates    = $io_weblogic::certificates,
   $trustcacerts    = $io_weblogic::trustcacerts,
-) inherits io_weblogic {
+) {
 
   $pia_domain_list.each |$domain_name, $pia_domain_info| {
 

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/psadmin-io/psadminio-io_weblogic",
   "tags": ["PeopleSoft", "PeopleTools", "DPK", "psadmin.io"],
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0 < 4.13.0"},
     {"name":"puppetlabs-inifile","version_requirement":">= 1.5.0"},
     {"name":"puppetlabs-java_ks","version_requirement":">= 1.4.1"},
     {"name":"puppet-archive","version_requirement":"0.5.1"}


### PR DESCRIPTION
Implementing prams.pp properly and removing explicit hiera lookups from the module. This will give users the option to use whatever hiera lookup they need for their environment in a profile and call the module class with parameters.